### PR TITLE
Add CoT reward option for GRPO

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,15 @@ python train_spectral_vlm.py --data_dir tokenized_baseline/data
 torchrun --nproc_per_node=2 train_spectral_vlm.py --data_dir tokenized_baseline/data
 ```
 
+#### GRPO Fine-Tuning:
+```bash
+# Fine-tune a pretrained Spectral VLM using GRPO
+cd training
+python train_spectral_grpo.py --config configs/spectral_grpo_config.yaml --checkpoint path/to/spectral_checkpoint.pt
+```
+The `spectral_grpo_config.yaml` file enables `cot_reward` to encourage the `<thinking>...</thinking><answer>...</answer>` output format.
+
+
 ### Model Checkpoints
 
 #### Pretrained Models:

--- a/configs/spectral_grpo_config.yaml
+++ b/configs/spectral_grpo_config.yaml
@@ -1,0 +1,36 @@
+# Spectral VLM GRPO Fine-tuning Configuration
+model:
+  spectral_encoder_type: 'convnext'
+  ir_as_prompt: false
+  max_length: 1024
+  include_images: false
+
+vlm_checkpoint:
+  path: "checkpoints/nanoVLM-222M"
+  load_backbone: true
+
+data:
+  data_dir: "data/reshaped_tokenized_data/data"
+
+training:
+  batch_size: 1
+  logging_frequency: 10
+  validation_frequency: 50
+
+rl:
+  grpo:
+    group_size: 8
+    micro_group_size: 1
+    batch_size: 1
+    max_iterations: 1000
+    learning_rate: 1.0e-5
+    epsilon: 1
+    beta: 0.1
+    temperature: 1
+    log_wandb: false
+    exact_match_reward: true
+    tanimoto_reward: true
+    ecfp6_reward: true
+    valid_smiles_reward: true
+    mcs_ratio_reward: true
+    cot_reward: true

--- a/training/train_grpo.py
+++ b/training/train_grpo.py
@@ -66,6 +66,7 @@ class GRPO:
         use_ecfp6_reward=False,
         use_valid_smiles_reward=False,
         use_mcs_ratio_reward=False,
+        use_cot_reward=False,
         temperature=1,
         device=None,
         use_kl=True,
@@ -127,9 +128,17 @@ class GRPO:
         self.use_ecfp6_reward = use_ecfp6_reward
         self.use_valid_smiles_reward = use_valid_smiles_reward
         self.use_mcs_ratio_reward = use_mcs_ratio_reward
+        self.use_cot_reward = use_cot_reward
         
         # Ensure at least one reward is active
-        assert self.use_exact_match_reward or self.use_tanimoto_reward or self.use_ecfp6_reward or self.use_valid_smiles_reward or self.use_mcs_ratio_reward, "At least one reward function must be enabled"
+        assert (
+            self.use_exact_match_reward
+            or self.use_tanimoto_reward
+            or self.use_ecfp6_reward
+            or self.use_valid_smiles_reward
+            or self.use_mcs_ratio_reward
+            or self.use_cot_reward
+        ), "At least one reward function must be enabled"
         
         # Print reward configuration
         print(f"[GRPO] 🎯 Active rewards:")
@@ -138,6 +147,7 @@ class GRPO:
         print(f"  - ECFP6 reward: {'✓' if self.use_ecfp6_reward else '✗'}")
         print(f"  - Valid SMILES reward: {'✓' if self.use_valid_smiles_reward else '✗'}")
         print(f"  - MCS Ratio reward: {'✓' if self.use_mcs_ratio_reward else '✗'}")
+        print(f"  - CoT structure reward: {'✓' if self.use_cot_reward else '✗'}")
 
         # For the MultiModal model, we're not using LoRA adapters
         self.using_lora = False
@@ -418,19 +428,31 @@ class GRPO:
         total_tanimoto = 0.0
         total_ecfp6 = 0.0
         total_mcs_ratio = 0.0
+        total_cot = 0.0
         
         # Match generated SMILES with their targets based on group position
         for i, generated in enumerate(generated_smiles):
             target_idx = i % batch_size  # Cycle through targets based on group position
             target = original_targets[target_idx]
-            
+
+            # Extract potential answer from CoT formatted string
+            parsed_answer = parse_cot_answer(generated)
+            gen_for_eval = parsed_answer if parsed_answer else generated
+
             # Initialize reward for this sample
             reward = 0.0
-            
+
+            # CoT structure reward
+            cot_score = 0.0
+            if self.use_cot_reward:
+                cot_score = cot_structure_reward(generated)
+                reward += cot_score
+                total_cot += cot_score
+
             # Apply exact match reward if enabled
             exact_match_score = 0.0
             if self.use_exact_match_reward:
-                exact_match_score = exact_match_reward(target, generated)
+                exact_match_score = exact_match_reward(target, gen_for_eval)
                 reward += exact_match_score
                 if exact_match_score > 0:
                     exact_matches += 1
@@ -438,21 +460,21 @@ class GRPO:
             # Apply Tanimoto similarity reward if enabled
             tanimoto_score = 0.0
             if self.use_tanimoto_reward:
-                tanimoto_score = tanimoto_reward(target, generated)
+                tanimoto_score = tanimoto_reward(target, gen_for_eval)
                 reward += tanimoto_score
                 total_tanimoto += tanimoto_score
             
             # Apply ECFP6 reward if enabled
             ecfp6_score = 0.0
             if self.use_ecfp6_reward:
-                ecfp6_score = ecfp6_reward(target, generated)
+                ecfp6_score = ecfp6_reward(target, gen_for_eval)
                 reward += ecfp6_score
                 total_ecfp6 += ecfp6_score
             
             # Apply MCS ratio reward if enabled
             mcs_ratio_score = 0.0
             if self.use_mcs_ratio_reward:
-                mcs_ratio_score = mcs_ratio_reward(target, generated)
+                mcs_ratio_score = mcs_ratio_reward(target, gen_for_eval)
                 reward += mcs_ratio_score
                 total_mcs_ratio += mcs_ratio_score
             
@@ -460,7 +482,7 @@ class GRPO:
             mol = None
             valid_smiles_score = 0.0
             try:
-                mol = Chem.MolFromSmiles(generated)
+                mol = Chem.MolFromSmiles(gen_for_eval)
                 if mol is not None:
                     valid_count += 1
                     valid_smiles_score = 1.0
@@ -486,6 +508,8 @@ class GRPO:
                     self.metrics["valid_smiles_rewards"].append(valid_smiles_score)
                 if self.use_mcs_ratio_reward:
                     self.metrics["mcs_ratio_rewards"].append(mcs_ratio_score)
+                if self.use_cot_reward:
+                    self.metrics["cot_rewards"].append(cot_score)
                 
                 if mol is not None:
                     self.metrics["valid_molecule"].append(1.0)
@@ -499,6 +523,7 @@ class GRPO:
         avg_tanimoto = total_tanimoto / total if self.use_tanimoto_reward else 0.0
         avg_ecfp6 = total_ecfp6 / total if self.use_ecfp6_reward else 0.0
         avg_mcs_ratio = total_mcs_ratio / total if self.use_mcs_ratio_reward else 0.0
+        avg_cot = total_cot / total if self.use_cot_reward else 0.0
         
         print(f"[GRPO] 📊 Reward stats:")
         print(f"  - Valid SMILES: {valid_count}/{total} ({valid_pct:.2f}%)")
@@ -510,6 +535,8 @@ class GRPO:
             print(f"  - Avg ECFP6 IoU: {avg_ecfp6:.4f}")
         if self.use_mcs_ratio_reward:
             print(f"  - Avg MCS ratio: {avg_mcs_ratio:.4f}")
+        if self.use_cot_reward:
+            print(f"  - CoT format rate: {avg_cot:.4f}")
         
         print(f"[DEBUG] Exact match rate: {exact_matches}/{total} = {exact_matches/total:.4f}")
         
@@ -528,6 +555,8 @@ class GRPO:
                 self.metrics["avg_ecfp6"].append(avg_ecfp6)
             if self.use_mcs_ratio_reward:
                 self.metrics["avg_mcs_ratio"].append(avg_mcs_ratio)
+            if self.use_cot_reward:
+                self.metrics["avg_cot"].append(avg_cot)
         
         return rewards.tolist()
 
@@ -1002,6 +1031,23 @@ def mcs_ratio_reward(target, generated):
     except:
         return 0.0
 
+def parse_cot_answer(text: str) -> str:
+    """Extract the answer portion from a CoT-formatted string."""
+    if "<answer>" in text and "</answer>" in text:
+        return text.split("<answer>")[1].split("</answer>")[0].strip()
+    return ""
+
+
+def cot_structure_reward(text: str) -> float:
+    """Reward if the text follows the <thinking>...</thinking><answer>...</answer> template."""
+    required_tags = ["<thinking>", "</thinking>", "<answer>", "</answer>"]
+    if all(tag in text for tag in required_tags):
+        if text.count("<thinking>") == 1 and text.count("</thinking>") == 1 and text.count("<answer>") == 1 and text.count("</answer>") == 1:
+            if text.index("</thinking>") < text.index("<answer>"):
+                if text.split("</answer>")[1].strip() == "":
+                    return 1.0
+    return 0.0
+
 def load_pretrained_model(checkpoint_path, config, device):
     """Load a pretrained model from a checkpoint"""
     print(f"Loading pretrained model from {checkpoint_path}")
@@ -1064,6 +1110,7 @@ def main():
     parser.add_argument('--ecfp6-reward', type=lambda s: s.lower() in ["true", "1", "yes"], default=None, help='Use ECFP6 IoU reward (true/false)')
     parser.add_argument('--valid-smiles-reward', type=lambda s: s.lower() in ["true", "1", "yes"], default=None, help='Use valid SMILES reward (true/false)')
     parser.add_argument('--mcs-ratio-reward', type=lambda s: s.lower() in ["true", "1", "yes"], default=None, help='Use MCS ratio reward (true/false)')
+    parser.add_argument('--cot-reward', type=lambda s: s.lower() in ["true", "1", "yes"], default=None, help='Reward correct CoT format (true/false)')
     parser.add_argument('--log-frequency', type=int, default=None, help='Number of iterations between metric logging')
     parser.add_argument('--validation-frequency', type=int, default=None, help='Number of iterations between validations')
 
@@ -1111,8 +1158,10 @@ def main():
                                             else config['rl']['grpo'].get('ecfp6_reward', True))
     config['rl']['grpo']['valid_smiles_reward'] = (args.valid_smiles_reward if args.valid_smiles_reward is not None 
                                                     else config['rl']['grpo'].get('valid_smiles_reward', True))
-    config['rl']['grpo']['mcs_ratio_reward'] = (args.mcs_ratio_reward if args.mcs_ratio_reward is not None 
+    config['rl']['grpo']['mcs_ratio_reward'] = (args.mcs_ratio_reward if args.mcs_ratio_reward is not None
                                                  else config['rl']['grpo'].get('mcs_ratio_reward', True))
+    config['rl']['grpo']['cot_reward'] = (args.cot_reward if args.cot_reward is not None
+                                          else config['rl']['grpo'].get('cot_reward', False))
 
     log_frequency = (args.log_frequency if args.log_frequency is not None 
                      else config['training'].get('logging_frequency', 10))
@@ -1196,14 +1245,16 @@ def main():
     print(f"- ECFP6 reward: {'ENABLED' if config['rl']['grpo']['ecfp6_reward'] else 'DISABLED'}")
     print(f"- Valid SMILES reward: {'ENABLED' if config['rl']['grpo']['valid_smiles_reward'] else 'DISABLED'}")
     print(f"- MCS Ratio reward: {'ENABLED' if config['rl']['grpo']['mcs_ratio_reward'] else 'DISABLED'}")
+    print(f"- CoT format reward: {'ENABLED' if config['rl']['grpo']['cot_reward'] else 'DISABLED'}")
     print(f"==================================\n")
     
     # Ensure at least one reward is active
     if not (config['rl']['grpo']['exact_match_reward'] or 
             config['rl']['grpo']['tanimoto_reward'] or 
             config['rl']['grpo']['ecfp6_reward'] or 
-            config['rl']['grpo']['valid_smiles_reward'] or 
-            config['rl']['grpo']['mcs_ratio_reward']):
+            config['rl']['grpo']['valid_smiles_reward'] or
+            config['rl']['grpo']['mcs_ratio_reward'] or
+            config['rl']['grpo']['cot_reward']):
         print("ERROR: At least one reward function must be enabled!")
         return
 
@@ -1235,6 +1286,7 @@ def main():
         use_ecfp6_reward=config['rl']['grpo']['ecfp6_reward'],
         use_valid_smiles_reward=config['rl']['grpo']['valid_smiles_reward'],
         use_mcs_ratio_reward=config['rl']['grpo']['mcs_ratio_reward'],
+        use_cot_reward=config['rl']['grpo']['cot_reward'],
         log_wandb=config['rl']['grpo']['log_wandb'],
         lr=config['rl']['grpo']['learning_rate'],
         beta=config['rl']['grpo']['beta'],

--- a/training/train_spectral_grpo.py
+++ b/training/train_spectral_grpo.py
@@ -1,0 +1,149 @@
+import argparse
+import json
+from pathlib import Path
+import yaml
+import torch
+from torch.utils.data import DataLoader, Dataset
+import numpy as np
+
+from nanoVLM.models.spectral_vision_language_model import SpectralVisionLanguageModel
+from nanoVLM.models.config import VLMConfig
+from training.data.processors import get_tokenizer
+from training.train_grpo import GRPO
+
+class SpectralVLMRLDataset(Dataset):
+    """Simple dataset returning SMILES tokens, IR spectra and NMR tokens."""
+    def __init__(self, data_dir, tokenizer, split="train", max_length=512):
+        self.data_dir = Path(data_dir)
+        self.tokenizer = tokenizer
+        self.split = split
+        self.max_length = max_length
+        self._load_data()
+
+    def _load_data(self):
+        with open(self.data_dir / f"tgt-{self.split}.txt") as f:
+            self.smiles = [line.strip().replace(" ", "") for line in f]
+        with open(self.data_dir / f"src-{self.split}.txt") as f:
+            self.nmr = [line.strip() for line in f]
+        ir_path = self.data_dir / f"ir-{self.split}.npy"
+        self.ir = None
+        if ir_path.exists():
+            self.ir = np.load(ir_path, mmap_mode="r")
+
+    def __len__(self):
+        return len(self.smiles)
+
+    def __getitem__(self, idx):
+        smi = self.smiles[idx]
+        nmr = self.nmr[idx]
+        tgt_ids = self.tokenizer.encode(
+            smi, add_special_tokens=True, max_length=self.max_length, truncation=True
+        )
+        nmr_ids = self.tokenizer.encode(
+            nmr, add_special_tokens=True, max_length=self.max_length, truncation=True
+        )
+        ir_tensor = None
+        if self.ir is not None:
+            ir_tensor = torch.tensor(self.ir[idx], dtype=torch.float32)
+        return (
+            torch.tensor(tgt_ids, dtype=torch.long),
+            ir_tensor,
+            torch.tensor(nmr_ids, dtype=torch.long),
+            None,
+        )
+
+
+def collate_rl_fn(batch, tokenizer):
+    targets, ir_list, nmr_list, _ = zip(*batch)
+    max_t = max(len(t) for t in targets)
+    pad_id = tokenizer.pad_token_id
+    tgt_batch = torch.stack([
+        torch.cat([t, torch.full((max_t - len(t),), pad_id, dtype=torch.long)]) if len(t) < max_t else t
+        for t in targets
+    ])
+    max_n = max(len(n) for n in nmr_list)
+    nmr_batch = torch.stack([
+        torch.cat([n, torch.full((max_n - len(n),), pad_id, dtype=torch.long)]) if len(n) < max_n else n
+        for n in nmr_list
+    ])
+    ir_batch = None
+    if ir_list[0] is not None:
+        ir_batch = torch.stack(ir_list)
+    return tgt_batch, ir_batch, nmr_batch, None
+
+
+def load_config(path):
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def create_data_loaders(tokenizer, cfg):
+    data_dir = cfg["data"]["data_dir"]
+    max_len = cfg["model"].get("max_length", 512)
+    batch_size = cfg["training"].get("batch_size", 1)
+    train_ds = SpectralVLMRLDataset(data_dir, tokenizer, split="train", max_length=max_len)
+    val_ds = SpectralVLMRLDataset(data_dir, tokenizer, split="val", max_length=max_len)
+    collate = lambda b: collate_rl_fn(b, tokenizer)
+    train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=True, collate_fn=collate)
+    val_loader = DataLoader(val_ds, batch_size=batch_size, shuffle=False, collate_fn=collate)
+    return train_loader, val_loader
+
+
+def load_model(checkpoint_path, cfg, spectral_cfg, device):
+    with open(Path(cfg["vlm_checkpoint"]["path"]) / "config.json") as f:
+        vlm_conf = VLMConfig(**json.load(f).get("vlm_config", {}))
+    model = SpectralVisionLanguageModel(vlm_conf, load_backbone=True, spectral_cfg=spectral_cfg)
+    state = torch.load(checkpoint_path, map_location=device)
+    model.load_state_dict(state["model_state_dict"])
+    model.to(device)
+    return model
+
+
+def main():
+    parser = argparse.ArgumentParser(description="GRPO fine-tuning for SpectralVLM")
+    parser.add_argument("--config", default="configs/spectral_grpo_config.yaml")
+    parser.add_argument("--checkpoint", required=True, help="Path to pretrained SpectralVLM checkpoint")
+    args = parser.parse_args()
+
+    cfg = load_config(args.config)
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    tokenizer = get_tokenizer()
+
+    train_loader, val_loader = create_data_loaders(tokenizer, cfg)
+
+    spectral_cfg = {
+        "embed_dim": cfg.get("embed_dim", 768),
+        "encoder_type": cfg["model"].get("spectral_encoder_type", "convnext"),
+        "ir_as_prompt": cfg["model"].get("ir_as_prompt", False),
+    }
+
+    model = load_model(args.checkpoint, cfg, spectral_cfg, device)
+
+    grpo_cfg = cfg["rl"]["grpo"]
+    grpo = GRPO(
+        model=model,
+        ref_model=None,
+        tokenizer=tokenizer,
+        group_size=grpo_cfg.get("group_size", 8),
+        micro_group_size=grpo_cfg.get("micro_group_size", 1),
+        batch_size=grpo_cfg.get("batch_size", 1),
+        max_iterations=grpo_cfg.get("max_iterations", 1000),
+        train_loader=train_loader,
+        val_loader=val_loader,
+        log_wandb=grpo_cfg.get("log_wandb", False),
+        lr=grpo_cfg.get("learning_rate", 1e-5),
+        beta=grpo_cfg.get("beta", 0.1),
+        epsilon=grpo_cfg.get("epsilon", 1.0),
+        temperature=grpo_cfg.get("temperature", 1.0),
+        use_cot_reward=grpo_cfg.get("cot_reward", False),
+        device=device,
+        use_kl=True,
+        log_frequency=cfg["training"].get("logging_frequency", 1),
+        validation_frequency=cfg["training"].get("validation_frequency", 10),
+    )
+
+    grpo.train(num_iterations=grpo_cfg.get("max_iterations", 1000))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- allow GRPO training scripts to reward chain-of-thought formatted outputs
- add `cot_reward` flag in `spectral_grpo_config.yaml`
- support the new reward in `train_spectral_grpo.py`
- document the option in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*